### PR TITLE
Allow automatic refresh to be optional

### DIFF
--- a/src/apis/dfp.ts
+++ b/src/apis/dfp.ts
@@ -16,7 +16,7 @@ const googleTag = () => {
 };
 
 export const dfp = {
-  createSlots: (ads: AdItem[], enableLazyload: boolean) => {
+  createSlots: (ads: AdItem[], enableLazyload: boolean, enableRefresh: boolean = true) => {
     googleTag().cmd.push(() => {
       googleTag().pubads().collapseEmptyDivs();
 
@@ -62,17 +62,19 @@ export const dfp = {
         }
       });
 
-      googleTag()
-        .pubads()
-        .addEventListener("impressionViewable", (event) => {
-          const slot = event.slot;
+      if (enableRefresh) {
+        googleTag()
+          .pubads()
+          .addEventListener("impressionViewable", (event) => {
+            const slot = event.slot;
 
-          if (slot.getTargeting(REFRESH_KEY).indexOf(REFRESH_VALUE) > -1) {
-            setTimeout(() => {
-              googleTag().pubads().refresh([slot]);
-            }, SECONDS_TO_WAIT_AFTER_VIEWABILITY * 1000);
-          }
-        });
+            if (slot.getTargeting(REFRESH_KEY).indexOf(REFRESH_VALUE) > -1) {
+              setTimeout(() => {
+                googleTag().pubads().refresh([slot]);
+              }, SECONDS_TO_WAIT_AFTER_VIEWABILITY * 1000);
+            }
+          });
+      }
 
       if (!!enableLazyload) {
         // Enable lazyload with some good defaults

--- a/src/components/AdsProvider/index.tsx
+++ b/src/components/AdsProvider/index.tsx
@@ -12,6 +12,7 @@ export const AdsProvider: AdsProviderComponent = ({
   children,
   debug = false,
   enableLazyload = true,
+  enableRefresh = true, // new prop to enable/disable refresh
 }) => {
   const [isLoading, setIsLoading] = useState(true);
 
@@ -21,7 +22,7 @@ export const AdsProvider: AdsProviderComponent = ({
   useEffect(() => {
     setIsLoading(true);
 
-    dfp.createSlots(ads, enableLazyload);
+    dfp.createSlots(ads, enableLazyload, enableRefresh);
 
     setIsLoading(false);
 
@@ -29,7 +30,7 @@ export const AdsProvider: AdsProviderComponent = ({
       if (window.location.pathname !== url) {
         setIsLoading(true);
         dfp.removeSlots();
-        dfp.createSlots(ads, enableLazyload);
+        dfp.createSlots(ads, enableLazyload, enableRefresh); // pass enableRefresh prop to createSlots()
       }
     };
 
@@ -44,7 +45,7 @@ export const AdsProvider: AdsProviderComponent = ({
       router.events.off("routeChangeStart", handleRouteChangeStart);
       router.events.off("routeChangeComplete", handleRouteChangeComplete);
     };
-  }, [ads, enableLazyload]);
+  }, [ads, enableLazyload, enableRefresh]);
 
   // Enable debug console if possible
   useEffect(() => {

--- a/src/components/AdsProvider/index.tsx
+++ b/src/components/AdsProvider/index.tsx
@@ -12,7 +12,7 @@ export const AdsProvider: AdsProviderComponent = ({
   children,
   debug = false,
   enableLazyload = true,
-  enableRefresh = true, // new prop to enable/disable refresh
+  enableRefresh = true
 }) => {
   const [isLoading, setIsLoading] = useState(true);
 
@@ -30,7 +30,7 @@ export const AdsProvider: AdsProviderComponent = ({
       if (window.location.pathname !== url) {
         setIsLoading(true);
         dfp.removeSlots();
-        dfp.createSlots(ads, enableLazyload, enableRefresh); // pass enableRefresh prop to createSlots()
+        dfp.createSlots(ads, enableLazyload, enableRefresh);
       }
     };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,7 +34,7 @@ export type AdsProviderComponent = React.FC<AdsProviderProps>;
 
 type AdProps = {
   id: string;
-  style?: object;
+  style?: React.CSSProperties
   className?: string;
   width: number | string;
   height: number | string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,13 +27,14 @@ type AdsProviderProps = {
   ads: AdItem[];
   debug?: boolean;
   enableLazyload?: boolean;
+  enableRefresh?: boolean;
 };
 
 export type AdsProviderComponent = React.FC<AdsProviderProps>;
 
 type AdProps = {
   id: string;
-  style?: any;
+  style?: object;
   className?: string;
   width: number | string;
   height: number | string;


### PR DESCRIPTION
- Adds a new option to the `createSlots` that if set to `false` disables the automatic ad refresh. This option defaults to `true`.
- Changed the `style` prop of the `AdProps` to be a type of `React.CSSProperties`.